### PR TITLE
added parameter -AsObject

### DIFF
--- a/PSEverything/Everything.cs
+++ b/PSEverything/Everything.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using static PSEverything.Status;
+using System.IO;
 
 namespace PSEverything
 {
@@ -25,7 +26,7 @@ namespace PSEverything
         public static void SetSearch(string text)
         {
             int res = Is64Bit ? NativeMethods64.Everything_SetSearchW(text) : NativeMethods32.Everything_SetSearchW(text);
-            if (res != (int) Ok)
+            if (res != (int)Ok)
             {
                 Throw(res);
             }
@@ -128,6 +129,15 @@ namespace PSEverything
 
             return buf.ToString();
         }
+        public static bool GetIsFolderResult(int index)
+        {
+            return Is64Bit ? NativeMethods64.Everything_IsFolderResult(nIndex: index) : NativeMethods32.Everything_IsFolderResult(nIndex: index);
+        }
+
+        public static bool GetIsFileResult(int index)
+        {
+            return Is64Bit ? NativeMethods64.Everything_IsFileResult(nIndex: index) : NativeMethods32.Everything_IsFileResult(nIndex: index);
+        }
 
         public static void Cleanup()
         {
@@ -146,6 +156,22 @@ namespace PSEverything
             {
                 var path = GetFullPathName(i, buf);
                 retVal[i] = path;
+                buf.Clear();
+            }
+            return retVal;
+        }
+
+        public static FileSystemInfo[] GetAllResultsAsFileSystemInfo(int count)
+        {
+            FileSystemInfo[] retVal = new FileSystemInfo[count];
+            StringBuilder buf = new(32767);
+
+            for (int i = 0; i < count; ++i)
+            {
+                string path = GetFullPathName(i, buf);
+                retVal[i] = GetIsFileResult(i) ? (FileSystemInfo)new FileInfo(path)
+                            : GetIsFolderResult(i) ? new DirectoryInfo(path)
+                            : null;
                 buf.Clear();
             }
             return retVal;

--- a/PSEverything/PSEverything.csproj
+++ b/PSEverything/PSEverything.csproj
@@ -22,7 +22,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="PowerShellStandard.Library" Version="5.1.0-preview-01" />
+        <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/PSEverything/PSEverything.psd1
+++ b/PSEverything/PSEverything.psd1
@@ -1,24 +1,23 @@
 
 @{
-    RootModule = 'PSEverything.dll'
-    ModuleVersion = '3.3.0'
-    GUID = 'f262ec02-4a88-49e5-94da-e25aab9cbf7a'
-    Author = 'Staffan Gustafsson'
-    CompanyName = 'PowerCode Consulting AB'
-    Copyright = '(c) 2016 sgustafsson. All rights reserved.'
-    Description = 'Powershell access to Everything - Blazingly fast file system searches'
-    PowerShellVersion = '5.1'
+    RootModule           = 'PSEverything.dll'
+    ModuleVersion        = '3.3.1'
+    GUID                 = 'f262ec02-4a88-49e5-94da-e25aab9cbf7a'
+    Author               = 'Staffan Gustafsson'
+    CompanyName          = 'PowerCode Consulting AB'
+    Copyright            = '(c) 2016 sgustafsson. All rights reserved.'
+    Description          = 'Powershell access to Everything - Blazingly fast file system searches'
+    PowerShellVersion    = '5.1'
     CompatiblePSEditions = "Desktop", "Core"
-    FunctionsToExport = ''
-    CmdletsToExport = 'Search-Everything', 'Select-EverythingString'
-    VariablesToExport = ''
-    AliasesToExport = 'se', 'sles'
-    FileList = 'Everything32.dll', 'Everything64.dll', 'LICENSE', 'PSEverything.dll', 'PSEverything.dll-Help.xml', 'PSEverything.psd1'
-    PrivateData = @{
+    FunctionsToExport    = ''
+    CmdletsToExport      = 'Search-Everything', 'Select-EverythingString'
+    VariablesToExport    = ''
+    FileList             = 'Everything32.dll', 'Everything64.dll', 'LICENSE', 'PSEverything.dll', 'PSEverything.dll-Help.xml', 'PSEverything.psd1'
+    PrivateData          = @{
         PSData = @{
-            Tags = @('Search', 'Everything', 'voidtools', 'regex', 'grep')
-            LicenseUri = 'https://raw.githubusercontent.com/powercode/PSEverything/master/LICENSE'
-            ProjectUri = 'https://github.com/powercode/PSEverything'
+            Tags         = @('Search', 'Everything', 'voidtools', 'regex', 'grep')
+            LicenseUri   = 'https://raw.githubusercontent.com/powercode/PSEverything/master/LICENSE'
+            ProjectUri   = 'https://github.com/powercode/PSEverything'
             ReleaseNotes = @'
 2.3: Bug fixes. Sorted output.
 2.1: Upgrading to SDK matching 1.4.1.809b  - Fixing hang when calling from Eleveated powershell
@@ -38,4 +37,3 @@ Bug fix for -Filter that didn't work in combination with non-global searches.
         }
     }
 }
-

--- a/PSEverything/SelectEverythingStringCommand.cs
+++ b/PSEverything/SelectEverythingStringCommand.cs
@@ -8,8 +8,7 @@ using System.Collections.Generic;
 namespace PSEverything
 {
     [Cmdlet(VerbsCommon.Select, "EverythingString", DefaultParameterSetName = "default")]
-    [OutputType(new[]{"Microsoft.PowerShell.Commands.MatchInfo" })]
-    [Alias(new[] {"sles"})]
+    [OutputType(new[] { "Microsoft.PowerShell.Commands.MatchInfo" })]
     public class SelectEverythingStringCommand : PSCmdlet
     {
         static readonly string[] SearchParamNames = new[]{
@@ -49,7 +48,7 @@ namespace PSEverything
         [Parameter]
         public SwitchParameter NotMatch { get; set; }
 
-        [ValidateSet(new[]{"unicode", "utf7", "utf8", "utf32", "ascii", "bigendianunicode", "default", "oem" })]
+        [ValidateSet(new[] { "unicode", "utf7", "utf8", "utf32", "ascii", "bigendianunicode", "default", "oem" })]
         [ValidateNotNullOrEmpty]
         public string Encoding { get; set; }
 
@@ -71,19 +70,19 @@ namespace PSEverything
         public string[] Extension { get; set; }
 
         [Parameter(ParameterSetName = "default")]
-        [Alias(new[] {"pi"})]
+        [Alias(new[] { "pi" })]
         public string[] PathInclude { get; set; }
 
         [Parameter(ParameterSetName = "default")]
-        [Alias(new[] {"pe"})]
+        [Alias(new[] { "pe" })]
         public string[] PathExclude { get; set; }
 
         [Parameter(ParameterSetName = "default")]
-        [Alias(new[] {"fi"})]
+        [Alias(new[] { "fi" })]
         public string[] FolderInclude { get; set; }
 
         [Parameter(ParameterSetName = "default")]
-        [Alias(new[] {"fe"})]
+        [Alias(new[] { "fe" })]
         public string[] FolderExclude { get; set; }
 
         [Parameter(ParameterSetName = "default")]
@@ -124,7 +123,7 @@ namespace PSEverything
             {
                 if (bound.TryGetValue(sp, out object val))
                 {
-                    searchParams.Add(sp == nameof(CaseSensitiveSearch) ? "CaseSenitive" : sp, val);
+                    searchParams.Add(sp == nameof(CaseSensitiveSearch) ? "CaseSensitive" : sp, val);
                     bound.Remove(sp);
                 }
             }
@@ -135,7 +134,8 @@ namespace PSEverything
                 bound.Remove(nameof(CaseSensitivePattern));
             }
             var slsParams = bound;
-            using (_powershell = PowerShell.Create(RunspaceMode.CurrentRunspace)) {
+            using (_powershell = PowerShell.Create(RunspaceMode.CurrentRunspace))
+            {
                 _powershell.AddCommand("Search-Everything").AddParameters(searchParams);
                 var paths = _powershell.Invoke<string[]>().First();
                 if (_powershell.HadErrors)

--- a/PSEverythingStandard/Class1.cs
+++ b/PSEverythingStandard/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace PSEverythingStandard
-{
-    public class Class1
-    {
-    }
-}

--- a/Tests/PSEverythingTests/SelectEverythingTests.cs
+++ b/Tests/PSEverythingTests/SelectEverythingTests.cs
@@ -14,13 +14,14 @@ namespace PSEverythingTests
         public void TestSelectEverythingString()
         {
             var iss = InitialSessionState.CreateDefault2();
-            iss.ImportPSModule(new []{(typeof(SelectEverythingStringCommand).Assembly.Location)});
+            iss.ImportPSModule(new[] { (typeof(SelectEverythingStringCommand).Assembly.Location) });
             using (var ps = PowerShell.Create(iss))
             {
                 ps.Commands.AddCommand("Select-EverythingString")
-                  .AddParameter("-Extension", "ps1")
+                  .AddParameter("-Extension", "psd1")
                   .AddParameter("-Global", true)
-                  .AddParameter("-Pattern", "function (\\S+)");
+                  .AddParameter("-Pattern", "RootModule")
+                  .AddParameter("-Exclude", "$env:SystemRoot");
 
 
                 var res = ps.Invoke();


### PR DESCRIPTION
Hello,

* Added parameter `-AsObject` to return System.IO.FileSystemInfo object. (alias `-AsFS`)

also made some minor tweaks per some of the suggestions in issues
* removed alias se, sles
* fixed spelling on CaseSensitiveSearch
* removed -preview reference
* removed unused Class1.cs
* update test (now looking for .psd1 and RootModule) bit less resource intensive as opposed to looking up all functions in all ps1 files.. added exclusion for SystemRoot.


